### PR TITLE
GitHub pages deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ This project is my personal portfolio website. This is the second project in Mod
 
 ## 🚀 Live Demo <a name="live-demo"></a>
 
-- Coming Soon
+👉 [Link to Live Demo](https://henokkhm.github.io/portfolio-site/)
+
+This site is hosted on [GitHub pages](https://pages.github.com/).
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 

--- a/index.html
+++ b/index.html
@@ -1,0 +1,21 @@
+<!--
+GitHub pages requires the "entry file" to be either in the root folder or /docs
+
+The following stackoverflow solution shows how to create an index.html at / that redirects to another file
+https://stackoverflow.com/questions/25320356/can-i-have-my-github-pages-index-html-in-a-subfolder-of-the-repository/25327759#25327759
+-->
+
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      http-equiv="refresh"
+      content="0; url=https://henokkhm.github.io/portfolio-site/src/index.html"
+    />
+    <title>Personal Portfolio</title>
+  </head>
+  <body></body>
+</html>


### PR DESCRIPTION
This pull request adds the necessary changes to deploy the website to [GitHub pages](https://pages.github.com/).

GitHub Pages requires that the "entry file" (**index.html** or **README.md**) should either be in the **root** directory of the repo, or inside **/docs** folder. Since the previous folder structure differs from this requirement, I added an index.html at the root that simply redirects to the previous index.html file inside **/src**, using [this answer from StackOverflow](https://stackoverflow.com/questions/25320356/can-i-have-my-github-pages-index-html-in-a-subfolder-of-the-repository/25327759#25327759). 